### PR TITLE
In a container from rocker/verse the system's `PATH` and the R's `PATH` are different

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,3 +89,21 @@ With `pak`:
 ```R
 pak::pak("ixpantia/orbweaver-r")
 ```
+
+### Debugging installation issues
+
+Is .cargo/bin in your `PATH`?
+
+If `echo $PATH` includes `.cargo/bin` but `Sys.getenv("PATH")` doesn't, then add this to .Renviron:
+
+```
+# You can open .Renviron with `usethis::edit_r_environ()`
+PATH=${HOME}/.cargo/bin:${PATH}
+```
+
+Then restart R and install with:
+
+```r
+# `pak::pak()` may fails because it tries to to install cargo in a differetn way
+remotes::install_github("ixpantia/orbweaver-r")
+```


### PR DESCRIPTION
This is a fresh rocker/verse environment

```
root@bac7ae3e0007:/# lsb_release -a
No LSB modules are available.
Distributor ID:	Ubuntu
Description:	Ubuntu 24.04.1 LTS
Release:	24.04
Codename:	noble
```

I installed the Rust toolchain successfully using the instructions in README

```
curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
```

The shell finds .cargo/bin in the `PATH`

```
root@bac7ae3e0007:/# which cargo
/root/.cargo/bin/cargo
```

But R can't find it

```
root@bac7ae3e0007:/# Rscript -e "Sys.getenv('PATH')"
[1] "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/texlive/bin/linux:/usr/local/texlive/bin/linux/"
```

We can fix it by adding .cargo/bin to the `PATH` in .Renviron

```
root@bac7ae3e0007:/# echo "PATH=${HOME}/.cargo/bin:${PATH}" >> /root/.Renviron
root@bac7ae3e0007:/# Rscript -e "Sys.getenv('PATH')"
[1] "/root/.cargo/bin:/root/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/texlive/bin/linux"
```

I tried both as a root and normal user.

The problem seems specific to rocker/verse. In a container from ubuntu the `PATH` is alligned:

```bash
# As a normal user
mauro@fd442230bf36:~$ echo $PATH
/home/mauro/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin
mauro@fd442230bf36:~$ Rscript -e "Sys.getenv('PATH')"
[1] "/home/mauro/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin"

# As the root user
root@fd442230bf36:/# echo $PATH
/root/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
root@fd442230bf36:/# Rscript -e "Sys.getenv('PATH')"
[1] "/root/.cargo/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
```
