### PR TITLE
chore: Address R CMD NOTEs

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -32,3 +32,5 @@
 
 ^benchmarks/
 ^assets/
+^orbweaver\.Rproj$
+^Taskfile\.yml$

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ src/rust/vendor/
 docs
 .vscode
 src/rust/vendor
+.Rproj.user

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,6 +33,5 @@ Imports:
     rlang,
     methods
 Suggests: 
-    testthat (>= 3.0.0),
-    tibble
+    testthat (>= 3.0.0)
 Config/testthat/edition: 3

--- a/R/builder.R
+++ b/R/builder.R
@@ -67,10 +67,10 @@ build_acyclic <- function(graph_builder) {
   throw_if_error(graph_builder$build_acyclic())
 }
 
-#' @title Populates the edges of a graph from a `tibble`
-#' @description Adds a set of edges from a `tibble` to a graph
+#' @title Populates the edges of a graph from a `data.frame`
+#' @description Adds a set of edges from a `data.frame` to a graph
 #' @param graph_builder A graph builder object
-#' @param edges_df A `tibble` with a parent and child variable
+#' @param edges_df A `data.frame` with a parent and child variable
 #' @param parent_col The name of the column containing the parents
 #' @param child_col The name of the column containing the children
 #' @return The updated graph builder object

--- a/man/populate_edges.Rd
+++ b/man/populate_edges.Rd
@@ -2,14 +2,14 @@
 % Please edit documentation in R/builder.R
 \name{populate_edges}
 \alias{populate_edges}
-\title{Populates the edges of a graph from a \code{tibble}}
+\title{Populates the edges of a graph from a \code{data.frame}}
 \usage{
 populate_edges(graph_builder, edges_df, parent_col, child_col)
 }
 \arguments{
 \item{graph_builder}{A graph builder object}
 
-\item{edges_df}{A \code{tibble} with a parent and child variable}
+\item{edges_df}{A \code{data.frame} with a parent and child variable}
 
 \item{parent_col}{The name of the column containing the parents}
 
@@ -19,5 +19,5 @@ populate_edges(graph_builder, edges_df, parent_col, child_col)
 The updated graph builder object
 }
 \description{
-Adds a set of edges from a \code{tibble} to a graph
+Adds a set of edges from a \code{data.frame} to a graph
 }

--- a/tests/testthat/test-find_path.R
+++ b/tests/testthat/test-find_path.R
@@ -25,7 +25,7 @@ test_that("find all paths on directed acyclic graph", {
 
 test_that("find path from one node to many nodes", {
 
-  edges <- tibble::tibble(
+  edges <- data.frame(
     Parent = c("A", "A", "B", "C", "D", "Z"),
     Child = c("B", "C", "Z", "D", "Z", "F")
   )


### PR DESCRIPTION
* Closes #52

Note here I remove tibble from `Suggests:`. It was used only once in a test, and didn't relate to tibble. It seems like a good opportunity to make the package one soft dependency lighter. And we avoid this failure in the rare case CRAN decides to check behavoior without soft dependencies

```
══ Failed tests ════════════════════════════════════════════════════════════════
── Error ('test-find_path.R:28:3'): find path from one node to many nodes ──────
<packageNotFoundError/error/condition>
Error in `loadNamespace(x)`: there is no package called 'tibble'
Backtrace:
    ▆
 1. └─base::loadNamespace(x) at test-find_path.R:28:3
 2.   └─base::withRestarts(stop(cond), retry_loadNamespace = function() NULL)
 3.     └─base (local) withOneRestart(expr, restarts[[1L]])
 4.       └─base (local) doWithOneRestart(return(expr), restart)

[ FAIL 1 | WARN 0 | SKIP 0 | PASS 63 ]
```

https://github.com/ixpantia/orbweaver-r/actions/runs/13589523131/job/37991981452



